### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Also, for certain error-prone `clojure.core` functions, drop-in replacements are
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.collections "0.5.0"]
+[com.nedap.staffing-solutions/utils.collections "1.0.0"]
 ```
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.collections "0.5.0"
+(defproject com.nedap.staffing-solutions/utils.collections "1.0.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/utils.spec "0.9.0"]
                  [org.clojure/clojure "1.10.1"]]


### PR DESCRIPTION
* Fix Clojars setup
* No other significant changes
* Jumping to 1.0.0 for the usual reasons (no semver escape hatch)
  * Zero https://github.com/nedap/utils.collections/issues , so definitely stable