### PR TITLE
Relax spec for first!

### DIFF
--- a/src/nedap/utils/collections/eager.clj
+++ b/src/nedap/utils/collections/eager.clj
@@ -68,7 +68,7 @@
 
 (speced/defn first!
   "`clojure.core/first` which throws when a collection contains more than 1 item"
-  [^coll? coll]
+  [^seqable? coll]
   (if (<= (count coll) 1)
     (first coll)
     (throw (ex-info "Non unique collection" {:collection coll}))))

--- a/test/unit/nedap/utils/collections/eager.clj
+++ b/test/unit/nedap/utils/collections/eager.clj
@@ -1,9 +1,11 @@
 (ns unit.nedap.utils.collections.eager
   (:require
    [clojure.test :refer :all]
-   [nedap.utils.collections.eager :as sut])
+   [nedap.utils.collections.eager :as sut]
+   [nedap.utils.spec.api])
   (:import
-   (clojure.lang ExceptionInfo)))
+   (clojure.lang ExceptionInfo)
+   (java.util HashSet)))
 
 (deftest divide-by
   (testing "Basic behavior"
@@ -60,12 +62,25 @@
                                  #"Non unique collection"
                                  (sut/first! input))
     [1 2 3]
-    #{1 2 3})
+    #{1 2 3}
+    (HashSet. [1 2 3])
+    "abc")
 
   (are [input expected] (= expected
                            (sut/first! input))
-    [1]   1
-    [[1]] [1]
+    [1]            1
+    [[1]]          [1]
 
-    []    nil
-    [nil] nil))
+    []             nil
+    [nil]          nil
+
+    (HashSet.)     nil
+    (HashSet. [1]) 1
+
+    ""             nil
+    "a"            \a)
+
+  (when *assert*
+    (are [input] (spec-assertion-thrown? seqable? (sut/first! input))
+      :a
+      1)))


### PR DESCRIPTION
## Brief

Resolves #13

This change relaxes the spec on `first!` to support the same set of values that `clojure.core/first` supports. Meaning we can call `first!` on things like java collections, iterables, ...

The (maybe?) unfortunate side effect is that calling `(first! "a")` also works, just like `(clojure.core/first "a")` works. I'd say that is fine, as you can always tighten the spec in your consuming application.

## QA plan

None

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* [x] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
