### PR TITLE
 Fetch ncrw from GitHub instead of JFrog 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ workflows:
           <<: *test_code_filters
       - deploy:
           context:
+            - Clojars
             - Github
             - GPG
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ jobs:
           name: Perform pre-release sanity check
           command: lein with-profile -dev,+ci,+ncrw run -m nedap.ci.release-workflow.api sanity-check
       - run:
-          name: release to JFrog
-          command: lein deploy
-      - run:
           name: release to Clojars
           command: lein deploy clojars          
 
@@ -93,12 +90,10 @@ workflows:
           name: "Ensure artifact isolation, inform of boxed math"
           jdk_version: openjdk8
           lein_test_command: lein with-profile -dev,+check check
-          context: JFrog
           <<: *test_code_filters
       - cloverage:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, plain"
@@ -107,7 +102,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with production-like compiler flags"
@@ -116,7 +110,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, plain"
@@ -125,7 +118,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, with production-like compiler flags"
@@ -137,7 +129,9 @@ workflows:
           context: JFrog
           <<: *test_code_filters
       - deploy:
-          context: JFrog
+          context:
+            - Github
+            - GPG
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Also, for certain error-prone `clojure.core` functions, drop-in replacements are
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.collections "2.2.0"]
+[com.nedap.staffing-solutions/utils.collections "2.2.1-alpha1"]
 ```
 
 ## ns organisation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Also, for certain error-prone `clojure.core` functions, drop-in replacements are
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.collections "2.2.1-alpha1"]
+[com.nedap.staffing-solutions/utils.collections "2.2.1-alpha2"]
 ```
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.collections "2.2.0"
+(defproject com.nedap.staffing-solutions/utils.collections "2.2.1-alpha1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/speced.def "2.0.0"]
                  [com.nedap.staffing-solutions/utils.spec.predicates "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.collections "2.2.1-alpha1"
+(defproject com.nedap.staffing-solutions/utils.collections "2.2.1-alpha2"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/speced.def "2.0.0"]
                  [com.nedap.staffing-solutions/utils.spec.predicates "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -18,13 +18,9 @@
 
   :signing {:gpg-key "releases-staffingsolutions@nedap.com"}
 
-  :repositories {"releases" {:url      "https://nedap.jfrog.io/nedap/staffing-solutions/"
-                             :username :env/artifactory_user
-                             :password :env/artifactory_pass}}
-
-  :repository-auth {#"https://nedap.jfrog\.io/nedap/staffing-solutions/"
-                    {:username :env/artifactory_user
-                     :password :env/artifactory_pass}}
+  :repositories        {"github" {:url "https://maven.pkg.github.com/nedap/*"
+                                  :username "github"
+                                  :password :env/github_token}}
 
   :deploy-repositories {"clojars" {:url      "https://clojars.org/repo"
                                    :username :env/clojars_user
@@ -90,7 +86,7 @@
                           :test-paths     ^:replace []
                           :resource-paths ^:replace []
                           :plugins        ^:replace []
-                          :dependencies   ^:replace [[com.nedap.staffing-solutions/ci.release-workflow "1.13.1"]]}
+                          :dependencies   ^:replace [[com.nedap.staffing-solutions/ci.release-workflow "1.14.1"]]}
 
              :ci       {:pedantic?    :abort
                         :jvm-opts     ["-Dclojure.main.report=stderr"]}})


### PR DESCRIPTION
## Brief

Fetch ncrw from GitHub instead of JFrog.

## QA plan

- [x] https://clojars.org/com.nedap.staffing-solutions/utils.collections/versions/2.2.1-alpha2

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
